### PR TITLE
Make a framework for MCU's DeviceCommander compliancy

### DIFF
--- a/lib/DCSpecification/DCSpecification.h
+++ b/lib/DCSpecification/DCSpecification.h
@@ -1,0 +1,8 @@
+#ifndef DC_SPECIFICATION_H
+#define DC_SPECIFICATION_H
+
+class DCSpecification {
+    
+};
+
+#endif

--- a/lib/WiFiManagerWrapper/WiFiManagerWrapper.h
+++ b/lib/WiFiManagerWrapper/WiFiManagerWrapper.h
@@ -265,7 +265,7 @@ public:
       } else if (path == "/admin/reset") {
         Serial.println("Resetting.");
         this->wifiManager.resetSettings();
-        ESP.eraseConfig(); 
+        ESP.eraseConfig();
         delay(2000);
         ESP.reset();
       } else if (path == "/output/on") {
@@ -298,8 +298,10 @@ public:
 
     DynamicJsonDocument doc(1024);
 
-    doc["id"] = String(this->_ESP_ID);
+    doc["id"] = "esp-" + String(this->_ESP_ID);
+    doc["deviceType"] = "relay";
     doc["label"] = String(this->sensorLabel);
+    doc["mac"] = WiFi.macAddress();
 
     for ( auto paramValueIterator = this->paramValues.begin(); paramValueIterator != this->paramValues.end(); ++paramValueIterator  )
     {

--- a/lib/WiFiManagerWrapper/WiFiManagerWrapper.h
+++ b/lib/WiFiManagerWrapper/WiFiManagerWrapper.h
@@ -298,7 +298,7 @@ public:
 
     DynamicJsonDocument doc(1024);
 
-    doc["id"] = "esp-" + String(this->_ESP_ID);
+    doc["id"] = "esp82-" + String(this->_ESP_ID);
     doc["deviceType"] = "relay";
     doc["label"] = String(this->sensorLabel);
     doc["mac"] = WiFi.macAddress();

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,12 +8,22 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:d1_mini_lite]
+[env:d1_mini_lite_relay]
 platform = espressif8266
 board = d1_mini_lite
 monitor_speed = 115200
 framework = arduino
 build_src_filter = +<relay/>
+lib_deps = 
+	tzapu/WiFiManager@^0.16.0
+	bblanchon/ArduinoJson@^6.21.3
+
+[env:d1_mini_lite_temp_sensor]
+platform = espressif8266
+board = d1_mini_lite
+monitor_speed = 115200
+framework = arduino
+build_src_filter = +<temp_sensor/>
 lib_deps = 
 	tzapu/WiFiManager@^0.16.0
 	bblanchon/ArduinoJson@^6.21.3


### PR DESCRIPTION
This PR implements a means for easily implementing a DeviceCommander compliant device. It does so primarily by adding a webserver endpoint that returns a JSON specification object. This object is defined in the DeviceCommander code but it is re-implemented in C++ for arduino usage.